### PR TITLE
Add support for different AM550-TD0 identifier

### DIFF
--- a/components/wienernetze/wienernetze.cpp
+++ b/components/wienernetze/wienernetze.cpp
@@ -86,6 +86,11 @@ namespace esphome
                 ESP_LOGV(TAG, "Detected Iskraemeco AM550-TD0");
                 offset = -2;
             }
+            else if (memcmp(&msg[14], "ISKiu", 5) == 0)
+            {
+                ESP_LOGV(TAG, "Detected Iskraemeco AM550-TD0.21");
+                offset = -2;
+            }
             else
             {
                 ESP_LOGW(TAG, "Unknown smartmeter model, support is untested.");


### PR DESCRIPTION
My Iskraemeco AM550-TD0 has a different ID but works fine otherwise. On the device the exact model name is `AM550-TD0.21`, which might indicate a newer revision.